### PR TITLE
Fix GeoJsonPointSerializer return only latitude/longitude not array the

### DIFF
--- a/src/main/java/birt/eus/getyourroutebackend/model/serializer/GeoJsonPointSerializer.java
+++ b/src/main/java/birt/eus/getyourroutebackend/model/serializer/GeoJsonPointSerializer.java
@@ -15,7 +15,9 @@ public class GeoJsonPointSerializer extends JsonSerializer<GeoJsonPoint> {
         gen.writeStartObject();
         gen.writeStringField("type", value.getType());
         gen.writeArrayFieldStart("coordinates");
-        gen.writeObject(value.getCoordinates());
+        // gen.writeObject(value.getCoordinates());
+        gen.writeObject(value.getX());
+        gen.writeObject(value.getY());
         gen.writeEndArray();
         gen.writeEndObject();
     }


### PR DESCRIPTION
Fix GeoJsonPointSerializer return only latitude/longitude not array the latitude/longitude